### PR TITLE
Keep SELinux disabled by default

### DIFF
--- a/aosp-patches/aosp501-system-core-init-noselinux.patch
+++ b/aosp-patches/aosp501-system-core-init-noselinux.patch
@@ -6,7 +6,7 @@ index bd1db7a..03b401d 100644
  
  static bool selinux_is_disabled(void)
  {
-+    return false;
++    return true;
 +#if 0
  #ifdef ALLOW_DISABLE_SELINUX
      char tmp[PROP_VALUE_MAX];


### PR DESCRIPTION
Always return true from selinux_is_disabled() function in init
